### PR TITLE
Improve internal error handling, add unit tests for WiRoot and Airy

### DIFF
--- a/app/include/Structs.h
+++ b/app/include/Structs.h
@@ -25,7 +25,7 @@ struct LFMFParams {
         double d__km;        /**<  Path distance, in km                       */
         double epsilon;      /**<  Relative permittivity                      */
         double sigma;        /**<  Conductivity, in siemens per meter         */
-        int pol;             /**<  Polarization, 0 = Horizontal, 1 = Vertical */
+        ITS::Propagation::LFMF::Polarization pol;  /**<  Polarization (enum)  */
 };
 
 /** Key names for LFMF Model input file parameters */

--- a/app/src/LFMFModel.cpp
+++ b/app/src/LFMFModel.cpp
@@ -161,6 +161,6 @@ void WriteLFMFOutputs(std::ofstream &fp, const Result &result) {
     fp PRINT "Received power" SETW13 std::fixed << std::setprecision(2)
                                                 << result.P_rx__dbm << "[dB]";
     fp PRINT "Solution method" SETW13 std::fixed
-        << std::setprecision(0) << result.method
+        << std::setprecision(0) << static_cast<int>(result.method)
         << "[0 = Flat earth with curve correction, 1 = Residue series]";
 }

--- a/app/src/LFMFModel.cpp
+++ b/app/src/LFMFModel.cpp
@@ -31,7 +31,7 @@ const std::string LFMFInputKeys::pol = "pol";
  ******************************************************************************/
 ReturnCode CallLFMFModel(LFMFParams &lfmf_params, Result &result) {
     ReturnCode rtn;
-    rtn = LFMF(
+    rtn = LFMF_CPP(
         lfmf_params.h_tx__meter,
         lfmf_params.h_rx__meter,
         lfmf_params.f__mhz,
@@ -94,9 +94,13 @@ DrvrReturnCode
             if (rtn == DRVRERR__PARSE)
                 rtn = DRVRERR__PARSE_SIGMA;
         } else if (key.compare(LFMFInputKeys::pol) == 0) {
-            rtn = ParseInteger(value, lfmf_params.pol);
-            if (rtn == DRVRERR__PARSE)
+            int pol_int;
+            rtn = ParseInteger(value, pol_int);
+            if (rtn == DRVRERR__PARSE) {
                 rtn = DRVRERR__PARSE_POLARIZATION;
+            } else {
+                lfmf_params.pol = static_cast<Polarization>(pol_int);
+            }
         } else {
             std::cerr << "Unknown parameter: " << key << std::endl;
             rtn = DRVRERR__PARSE;
@@ -143,7 +147,7 @@ void WriteLFMFInputs(std::ofstream &fp, const LFMFParams &params) {
     fp PRINT LFMFInputKeys::d__km SETW13 params.d__km << "[km]";
     fp PRINT LFMFInputKeys::epsilon SETW13 params.epsilon;
     fp PRINT LFMFInputKeys::sigma SETW13 params.sigma;
-    fp PRINT LFMFInputKeys::pol SETW13 params.pol
+    fp PRINT LFMFInputKeys::pol SETW13 static_cast<int>(params.pol)
         << "[0 = Horizontal, 1 = Vertical]";
 }
 

--- a/include/LFMF.h
+++ b/include/LFMF.h
@@ -175,9 +175,7 @@ double ResidueSeries(
 );
 std::complex<double> wofz(const std::complex<double> z);
 std::complex<double> Airy(
-    const std::complex<double> Z,
-    const AiryKind kind,
-    const AiryScaling scaling
+    const std::complex<double> Z, const AiryKind kind, const AiryScaling scaling
 );
 std::complex<double> WiRoot(
     const int i,
@@ -197,7 +195,7 @@ ReturnCode ValidateInput(
     const double epsilon,
     const double sigma
 );
-ReturnCode ValidatePolarization(const int pol);
+ReturnCode ValidatePolarization(const Polarization pol);
 bool AlmostEqualRelative(
     const double A, const double B, const double maxRelDiff = DBL_EPSILON
 );

--- a/include/LFMF.h
+++ b/include/LFMF.h
@@ -49,10 +49,10 @@ enum SolutionMethod {
  * the same as Wait's @f$ w_2 @f$ and @f$ w_1 @f$.
  * @see ITS::Propagation::LFMF::Airy
  * @see ITS::Propagation::LFMF::WiRoot
- * @see ITS::Propagation::LFMF::AiryFunctionScaling
+ * @see ITS::Propagation::LFMF::AiryScaling
  ******************************************************************************/
 // clang-format off
-enum AiryFunctionKind {
+enum AiryKind {
     AIRY = 1, /**< Airy function of the first kind, @f$ \mathrm{Ai}(x) @f$ */
     AIRYD,    /**< Derivative of `AIRY`, @f$ \mathrm{Ai}'(x) @f$ */
     BAIRY,    /**< Airy function of the second kind, @f$ \mathrm{Bi}(x) @f$ */
@@ -72,9 +72,9 @@ enum AiryFunctionKind {
  * 
  * @see ITS::Propagation::LFMF::Airy
  * @see ITS::Propagation::LFMF::WiRoot
- * @see ITS::Propagation::LFMF::AiryFunctionKind
+ * @see ITS::Propagation::LFMF::AiryKind
  ******************************************************************************/
-enum AiryFunctionScaling {
+enum AiryScaling {
     HUFFORD, /**< Use Hufford scaling */
     WAIT,    /**< Use Wait scaling */
     NONE,    /**< No Scaling */
@@ -176,16 +176,16 @@ double ResidueSeries(
 std::complex<double> wofz(const std::complex<double> z);
 std::complex<double> Airy(
     const std::complex<double> Z,
-    const AiryFunctionKind kind,
-    const AiryFunctionScaling scaling
+    const AiryKind kind,
+    const AiryScaling scaling
 );
 std::complex<double> WiRoot(
     const int i,
     std::complex<double> &DWi,
     const std::complex<double> q,
     std::complex<double> &Wi,
-    const AiryFunctionKind kind,
-    const AiryFunctionScaling scaling
+    const AiryKind kind,
+    const AiryScaling scaling
 );
 ReturnCode ValidateInput(
     const double h_tx__meter,

--- a/include/LFMF.h
+++ b/include/LFMF.h
@@ -25,13 +25,13 @@ namespace LFMF {
 // Enums
 
 /** Valid RF polarizations for use of this model */
-enum Polarization {
+enum class Polarization {
     HORIZONTAL = 0, /**< Horizontal polarization */
     VERTICAL = 1,   /**< Vertical polarization */
 };
 
 /** Solution method used to generate model result */
-enum SolutionMethod {
+enum class SolutionMethod {
     FLAT_EARTH_CURVE, /**< Flat earth curve method */
     RESIDUE_SERIES,   /**< Residue series method */
 };
@@ -52,7 +52,7 @@ enum SolutionMethod {
  * @see ITS::Propagation::LFMF::AiryScaling
  ******************************************************************************/
 // clang-format off
-enum AiryKind {
+enum class AiryKind {
     AIRY = 1, /**< Airy function of the first kind, @f$ \mathrm{Ai}(x) @f$ */
     AIRYD,    /**< Derivative of `AIRY`, @f$ \mathrm{Ai}'(x) @f$ */
     BAIRY,    /**< Airy function of the second kind, @f$ \mathrm{Bi}(x) @f$ */
@@ -74,7 +74,7 @@ enum AiryKind {
  * @see ITS::Propagation::LFMF::WiRoot
  * @see ITS::Propagation::LFMF::AiryKind
  ******************************************************************************/
-enum AiryScaling {
+enum class AiryScaling {
     HUFFORD, /**< Use Hufford scaling */
     WAIT,    /**< Use Wait scaling */
     NONE,    /**< No Scaling */

--- a/src/Airy.cpp
+++ b/src/Airy.cpp
@@ -6,7 +6,6 @@
 
 #include <cmath>      // for abs, copysign, cos, exp, pow, sin, sqrt
 #include <complex>    // for std::arg, std::complex
-#include <ostream>    // for std::endl
 #include <sstream>    // for std::ostringstream
 #include <stdexcept>  // for std::invalid_argument, std::range_error
 
@@ -492,7 +491,7 @@ std::complex<double> Airy(
             << static_cast<int>(AiryKind::DWONE) << "), `WTWO` ("
             << static_cast<int>(AiryKind::WTWO) << "), `DWTWO` ("
             << static_cast<int>(AiryKind::DWTWO) << "), not "
-            << static_cast<int>(kind) << std::endl;
+            << static_cast<int>(kind);
         throw std::invalid_argument(oss.str());
     };
 
@@ -503,7 +502,7 @@ std::complex<double> Airy(
             << static_cast<int>(AiryScaling::NONE) << "), `HUFFORD` ("
             << static_cast<int>(AiryScaling::HUFFORD) << "), `WAIT` ("
             << static_cast<int>(AiryScaling::WAIT) << "), not "
-            << static_cast<int>(scaling) << std::endl;
+            << static_cast<int>(scaling);
         throw std::invalid_argument(oss.str());
     };
 

--- a/src/Airy.cpp
+++ b/src/Airy.cpp
@@ -480,13 +480,16 @@ std::complex<double> Airy(
     ////////////////////////////////////////
     // Validate inputs - kind & scaling   //
     ////////////////////////////////////////
-    if ((kind != AiryKind::AIRY) && (kind != AiryKind::BAIRY)
+    if ((kind != AiryKind::AIRY) && (kind != AiryKind::AIRYD)
+        && (kind != AiryKind::BAIRY) && (kind != AiryKind::BAIRYD)
         && (kind != AiryKind::WONE) && (kind != AiryKind::DWONE)
         && (kind != AiryKind::WTWO) && (kind != AiryKind::DWTWO)) {
         std::ostringstream oss;
         oss << "Airy(): `kind` must be one of `AIRY` ("
-            << static_cast<int>(AiryKind::AIRY) << "), `BAIRY` ("
-            << static_cast<int>(AiryKind::BAIRY) << "), `WONE` ("
+            << static_cast<int>(AiryKind::AIRY) << "), `AIRYD` ("
+            << static_cast<int>(AiryKind::AIRYD) << "), `BAIRY` ("
+            << static_cast<int>(AiryKind::BAIRY) << "), `BAIRYD` ("
+            << static_cast<int>(AiryKind::BAIRYD) << "), `WONE` ("
             << static_cast<int>(AiryKind::WONE) << "), `DWONE` ("
             << static_cast<int>(AiryKind::DWONE) << "), `WTWO` ("
             << static_cast<int>(AiryKind::WTWO) << "), `DWTWO` ("

--- a/src/Airy.cpp
+++ b/src/Airy.cpp
@@ -4,8 +4,11 @@
 
 #include "LFMF.h"
 
-#include <cmath>    // for abs, copysign, cos, exp, pow, sin, sqrt
-#include <complex>  // for std::arg, std::complex
+#include <cmath>      // for abs, copysign, cos, exp, pow, sin, sqrt
+#include <complex>    // for std::arg, std::complex
+#include <ostream>    // for std::endl
+#include <sstream>    // for std::ostringstream
+#include <stdexcept>  // for std::invalid_argument
 
 namespace ITS {
 namespace Propagation {
@@ -32,8 +35,11 @@ namespace LFMF {
  *
  * @param[in] Z        Complex input argument
  * @param[in] kind     Switch indicating the type of Airy function to solve
- * @param[in] scaling  Type of scaling to use
+ * @param[in] scaling  Type of scaling to use (any valid enum value)
  * @return             The desired Airy function calculated at Z
+ * 
+ * @throws std::invalid_argument If the values provided for `kind` or `scaling`
+ *                               are not valid for this function.
  *
  * @note The following is a note on scaling the output from this program.
  *
@@ -471,17 +477,32 @@ std::complex<double> Airy(
     };
 
     ////////////////////////////////////////
-    // Validate input - kind & derivative //
+    // Validate inputs - kind & scaling   //
     ////////////////////////////////////////
     if ((kind != AiryKind::AIRY) && (kind != AiryKind::BAIRY)
         && (kind != AiryKind::WONE) && (kind != AiryKind::DWONE)
         && (kind != AiryKind::WTWO) && (kind != AiryKind::DWTWO)) {
-        return std::complex<double>(0, 0);  // Airy Error: Invalid kind value
+        std::ostringstream oss;
+        oss << "Airy(): `kind` must be one of `AIRY` ("
+            << static_cast<int>(AiryKind::AIRY) << "), `BAIRY` ("
+            << static_cast<int>(AiryKind::BAIRY) << "), `WONE` ("
+            << static_cast<int>(AiryKind::WONE) << "), `DWONE` ("
+            << static_cast<int>(AiryKind::DWONE) << "), `WTWO` ("
+            << static_cast<int>(AiryKind::WTWO) << "), `DWTWO` ("
+            << static_cast<int>(AiryKind::DWTWO) << "), not "
+            << static_cast<int>(kind) << std::endl;
+        throw std::invalid_argument(oss.str());
     };
 
     if ((scaling != AiryScaling::NONE) && (scaling != AiryScaling::HUFFORD)
         && (scaling != AiryScaling::WAIT)) {
-        return std::complex<double>(0, 0);  // Airy Error: Invalid scaling value
+        std::ostringstream oss;
+        oss << "Airy(): `scaling` must be one of `NONE` ("
+            << static_cast<int>(AiryScaling::NONE) << "), `HUFFORD` ("
+            << static_cast<int>(AiryScaling::HUFFORD) << "), `WAIT` ("
+            << static_cast<int>(AiryScaling::WAIT) << "), not "
+            << static_cast<int>(scaling) << std::endl;
+        throw std::invalid_argument(oss.str());
     };
 
     // Set a flag and index value to control function flow based on whether or not

--- a/src/Airy.cpp
+++ b/src/Airy.cpp
@@ -111,14 +111,14 @@ namespace LFMF {
  * Ai(z) - j*Bi(z) = -3.526603e-001 + 1.265639e-001 i
  * Ai(z) + j*Bi(z) = -8.611221e-002 + 2.242080e-001 i
  * ```
- * @see ITS::Propagation::LFMF::AiryFunctionKind
- * @see ITS::Propagation::LFMF::AiryFunctionScaling
+ * @see ITS::Propagation::LFMF::AiryKind
+ * @see ITS::Propagation::LFMF::AiryScaling
  * @see ITS::Propagation::LFMF::WiRoot
  ******************************************************************************/
 std::complex<double> Airy(
     const std::complex<double> Z,
-    const AiryFunctionKind kind,
-    const AiryFunctionScaling scaling
+    const AiryKind kind,
+    const AiryScaling scaling
 ) {
     // NQTT, ASLT data
     int NQTT[15] = {

--- a/src/Airy.cpp
+++ b/src/Airy.cpp
@@ -116,9 +116,7 @@ namespace LFMF {
  * @see ITS::Propagation::LFMF::WiRoot
  ******************************************************************************/
 std::complex<double> Airy(
-    const std::complex<double> Z,
-    const AiryKind kind,
-    const AiryScaling scaling
+    const std::complex<double> Z, const AiryKind kind, const AiryScaling scaling
 ) {
     // NQTT, ASLT data
     int NQTT[15] = {
@@ -491,12 +489,14 @@ std::complex<double> Airy(
     ////////////////////////////////////////
     // Validate input - kind & derivative //
     ////////////////////////////////////////
-    if ((kind != AIRY) && (kind != BAIRY) && (kind != WONE) && (kind != DWONE)
-        && (kind != WTWO) && (kind != DWTWO)) {
+    if ((kind != AiryKind::AIRY) && (kind != AiryKind::BAIRY)
+        && (kind != AiryKind::WONE) && (kind != AiryKind::DWONE)
+        && (kind != AiryKind::WTWO) && (kind != AiryKind::DWTWO)) {
         return std::complex<double>(0, 0);  // Airy Error: Invalid kind value
     };
 
-    if ((scaling != NONE) && (scaling != HUFFORD) && (scaling != WAIT)) {
+    if ((scaling != AiryScaling::NONE) && (scaling != AiryScaling::HUFFORD)
+        && (scaling != AiryScaling::WAIT)) {
         return std::complex<double>(0, 0);  // Airy Error: Invalid scaling value
     };
 
@@ -506,7 +506,8 @@ std::complex<double> Airy(
     // `derivative_flag` is generally used as a condition.
     bool derivative_flag;  // True if finding a derivative (e.g., Ai', Bi')
     int derivative_idx;    // Index used to get correct values from arrays
-    if (kind == DWTWO || kind == DWONE || kind == AIRYD || kind == BAIRYD) {
+    if (kind == AiryKind::DWTWO || kind == AiryKind::DWONE
+        || kind == AiryKind::AIRYD || kind == AiryKind::BAIRYD) {
         derivative_flag = true;
         derivative_idx = 1;
     } else {
@@ -524,21 +525,26 @@ std::complex<double> Airy(
 
     // The following scales the input parameter Z depending on what the user is trying to do.
     // If the user is trying to find just the Ai(Z), Ai'(Z), Bi(Z) or Bi'(Z) there is no scaling.
-    if (kind == AIRY || kind == BAIRY || kind == AIRYD || kind == BAIRYD) {
+    if (kind == AiryKind::AIRY || kind == AiryKind::BAIRY
+        || kind == AiryKind::AIRYD || kind == AiryKind::BAIRYD) {
         // For Ai(Z) and  Bi(Z) No translation in the complex plane
         U = std::complex<double>(1.0, 0.0);
     }
     // Note that W1 Wait = Wi(2) Hufford and W2 Wait = Wi(1) Hufford
     // So the following inequalities keep this all straight
-    else if (((kind == DWONE || kind == WONE) && scaling == HUFFORD)
-             || ((kind == DWTWO || kind == WTWO) && scaling == WAIT)) {
+    else if (((kind == AiryKind::DWONE || kind == AiryKind::WONE)
+              && scaling == AiryScaling::HUFFORD)
+             || ((kind == AiryKind::DWTWO || kind == AiryKind::WTWO)
+                 && scaling == AiryScaling::WAIT)) {
         // This corresponds to Wi(1)(Z) in Eqn 38 Hufford NTIA Report 87-219
         // or Wait W2
         U = std::complex<double>(
             std::cos(2.0 * PI / 3.0), std::sin(2.0 * PI / 3.0)
         );
-    } else if (((kind == DWTWO || kind == WTWO) && scaling == HUFFORD)
-               || ((kind == DWONE || kind == WONE) && scaling == WAIT)) {
+    } else if (((kind == AiryKind::DWTWO || kind == AiryKind::WTWO)
+                && scaling == AiryScaling::HUFFORD)
+               || ((kind == AiryKind::DWONE || kind == AiryKind::WONE)
+                   && scaling == AiryScaling::WAIT)) {
         // This corresponds to Wi(2)(Z) in Eqn 38 Hufford NTIA Report 87-219
         // or Wait W1
         U = std::complex<double>(
@@ -624,7 +630,7 @@ std::complex<double> Airy(
             // Calculate the first term of the Taylor Series
             // To do this we need to find the Airy or Bairy function at the center of
             // expansion, CoE, that has been precalculated in the arrays above.
-            if (kind == BAIRY || kind == BAIRYD) {
+            if (kind == AiryKind::BAIRY || kind == AiryKind::BAIRYD) {
                 Ai = BV[N - 1];    // Bi(CoE)
                 Aip = BPV[N - 1];  // Bi'(CoE)
             } else {               // All other cases use the Coe for Ai(z)
@@ -697,7 +703,7 @@ std::complex<double> Airy(
         ZA = std::sqrt(ZU);          // zeta^(1/2)
         ZT = (2.0 / 3.0) * ZU * ZA;  // NIST DLMF 9.7.1 => -(2/3)zeta^(3/2)
 
-        if (kind == BAIRY || kind == BAIRYD) {
+        if (kind == AiryKind::BAIRY || kind == AiryKind::BAIRYD) {
             one = 1.0;  // Terms for the Bairy sum do not alternate sign
         } else {
             one = -1.0;  // All other functions use the Airy whose sum alternates sign
@@ -750,7 +756,7 @@ std::complex<double> Airy(
         // Now do the final function that leads the sum depending on what the user wants.
         // The leading function has to be taken apart so that it can be assembled as necessary for
         // the possible two parts of the sum
-        if (kind == BAIRY || kind == BAIRYD) {
+        if (kind == AiryKind::BAIRY || kind == AiryKind::BAIRYD) {
             if (derivative_flag) {
                 ZB = std::sqrt(ZA);  // NIST DLMF 9.7.7
             } else {
@@ -800,13 +806,14 @@ std::complex<double> Airy(
     };
 
     // The final scaling factor is a function of the kind, derivative and scaling flags
-    if (scaling == NONE) {
+    if (scaling == AiryScaling::NONE) {
         // The number from the Taylor series or asymptotic calculation
         // does not need to multiplied by anything
         U = std::complex<double>(1.0, 0.0);
     }
     // Hufford Wi(1) and Wi'(1)
-    else if ((kind == WONE || kind == DWONE) && (scaling == HUFFORD)) {
+    else if ((kind == AiryKind::WONE || kind == AiryKind::DWONE)
+             && (scaling == AiryScaling::HUFFORD)) {
         if (derivative_flag) {
             U = 2.0
               * std::complex<double>(std::cos(PI / 3.0), std::sin(PI / 3.0));
@@ -816,7 +823,8 @@ std::complex<double> Airy(
         };
     }
     // Hufford Wi(2) and Wi'(2)
-    else if ((kind == WTWO || kind == DWTWO) && (scaling == HUFFORD)) {
+    else if ((kind == AiryKind::WTWO || kind == AiryKind::DWTWO)
+             && (scaling == AiryScaling::HUFFORD)) {
         if (derivative_flag) {
             U = 2.0
               * std::complex<double>(std::cos(-PI / 3.0), std::sin(-PI / 3.0));
@@ -826,7 +834,8 @@ std::complex<double> Airy(
         };
     }
     // Wait W1 and W1'
-    else if ((kind == WONE || kind == DWONE) && (scaling == WAIT)) {
+    else if ((kind == AiryKind::WONE || kind == AiryKind::DWONE)
+             && (scaling == AiryScaling::WAIT)) {
         if (derivative_flag) {
             U = std::complex<double>(
                 -1.0 * std::sqrt(3.0 * PI), -1.0 * std::sqrt(PI)
@@ -836,7 +845,8 @@ std::complex<double> Airy(
         };
     }
     // Wait W2 and W2'
-    else if ((kind == WTWO || kind == DWTWO) && (scaling == WAIT)) {
+    else if ((kind == AiryKind::WTWO || kind == AiryKind::DWTWO)
+             && (scaling == AiryScaling::WAIT)) {
         if (derivative_flag) {
             U = std::complex<double>(-1.0 * std::sqrt(3.0 * PI), std::sqrt(PI));
         } else {

--- a/src/LFMF.cpp
+++ b/src/LFMF.cpp
@@ -24,7 +24,10 @@ namespace LFMF {
  * @param[in]  sigma        Conductivity
  * @param[in]  pol          Polarization: 0 = Horizontal, 1 = Vertical
  * @param[out] result       Result structure
- * @return                  Error code
+ * @return                  Return code
+ * 
+ * @see ITS::Propagation::LFMF::Result
+ * @see ITS::Propagation::LFMF::ReturnCode
  ******************************************************************************/
 ReturnCode LFMF(
     const double h_tx__meter,
@@ -38,11 +41,7 @@ ReturnCode LFMF(
     const int pol,
     Result &result
 ) {
-    ReturnCode rtn = ValidatePolarization(pol);
-    if (rtn != SUCCESS)
-        return rtn;
-
-    return LFMF_CPP(
+    ReturnCode rtn = LFMF_CPP(
         h_tx__meter,
         h_rx__meter,
         f__mhz,
@@ -54,6 +53,7 @@ ReturnCode LFMF(
         static_cast<Polarization>(pol),
         result
     );
+    return rtn;
 }
 
 /*******************************************************************************
@@ -69,10 +69,11 @@ ReturnCode LFMF(
  * @param[in]  sigma        Conductivity
  * @param[in]  pol          Polarization: 0 = Horizontal, 1 = Vertical
  * @param[out] result       Result structure
- * @return                  Error code
+ * @return                  Return code
  * 
  * @see ITS::Propagation::LFMF::Polarization
  * @see ITS::Propagation::LFMF::Result
+ * @see ITS::Propagation::LFMF::ReturnCode
  ******************************************************************************/
 ReturnCode LFMF_CPP(
     const double h_tx__meter,
@@ -89,6 +90,9 @@ ReturnCode LFMF_CPP(
     ReturnCode rtn = ValidateInput(
         h_tx__meter, h_rx__meter, f__mhz, P_tx__watt, N_s, d__km, epsilon, sigma
     );
+    if (rtn != SUCCESS)
+        return rtn;
+    rtn = ValidatePolarization(pol);
     if (rtn != SUCCESS)
         return rtn;
 

--- a/src/ResidueSeries.cpp
+++ b/src/ResidueSeries.cpp
@@ -51,19 +51,22 @@ double ResidueSeries(
 
     for (int i = 0; i < 200; i++) {
         // find the (i+1)th root of Airy function for given q
-        T[i] = WiRoot(i + 1, DW2[i], q, W2[i], WONE, WAIT);
-        W1[i] = Airy(T[i], WONE, WAIT);  // Airy function of (i)th root
+        T[i] = WiRoot(
+            i + 1, DW2[i], q, W2[i], AiryKind::WONE, AiryScaling::WAIT
+        );
+        // Airy function of (i)th root
+        W1[i] = Airy(T[i], AiryKind::WONE, AiryScaling::WAIT);
 
         if (h_1__km > 0) {
-            W[i]
-                = Airy(T[i] - yLow, WONE, WAIT)
-                / W1[i];  //height gain function H_1(h_1) eqn.(22) from NTIA report 99-368
+            // Height gain function H_1(h_1) eqn.(22) from NTIA report 99-368
+            W[i] = Airy(T[i] - yLow, AiryKind::WONE, AiryScaling::WAIT) / W1[i];
 
             if (h_2__km > 0)
-                W[i] *= Airy(T[i] - yHigh, WONE, WAIT)
-                      / W1[i];  //H_1(h_1)*H_1(h_2)
+                W[i] *= Airy(T[i] - yHigh, AiryKind::WONE, AiryScaling::WAIT)
+                      / W1[i];  // H_1(h_1)*H_1(h_2)
         } else if (h_2__km > 0) {
-            W[i] = Airy(T[i] - yHigh, WONE, WAIT) / W1[i];
+            W[i]
+                = Airy(T[i] - yHigh, AiryKind::WONE, AiryScaling::WAIT) / W1[i];
         } else {
             W[i] = std::complex<double>(1, 0);
         }

--- a/src/ValidateInputs.cpp
+++ b/src/ValidateInputs.cpp
@@ -65,12 +65,12 @@ ReturnCode ValidateInput(
  * @param[in] pol  Polarization
  * @return         Return code
  ******************************************************************************/
-ReturnCode ValidatePolarization(const int pol) {
-    Polarization pol_cast = static_cast<Polarization>(pol);
-    if (pol_cast != Polarization::HORIZONTAL
-        && pol_cast != Polarization::VERTICAL)
+ReturnCode ValidatePolarization(const Polarization pol) {
+    if (pol != Polarization::HORIZONTAL && pol != Polarization::VERTICAL) {
         return ERROR__POLARIZATION;
-    return SUCCESS;
+    } else {
+        return SUCCESS;
+    }
 }
 
 }  // namespace LFMF

--- a/src/ValidateInputs.cpp
+++ b/src/ValidateInputs.cpp
@@ -66,7 +66,9 @@ ReturnCode ValidateInput(
  * @return         Return code
  ******************************************************************************/
 ReturnCode ValidatePolarization(const int pol) {
-    if (pol != Polarization::HORIZONTAL && pol != Polarization::VERTICAL)
+    Polarization pol_cast = static_cast<Polarization>(pol);
+    if (pol_cast != Polarization::HORIZONTAL
+        && pol_cast != Polarization::VERTICAL)
         return ERROR__POLARIZATION;
     return SUCCESS;
 }

--- a/src/WiRoot.cpp
+++ b/src/WiRoot.cpp
@@ -7,7 +7,7 @@
 #include <cmath>      // for abs, cos, pow, sin
 #include <complex>    // for std::complex
 #include <sstream>    // for std::ostringstream
-#include <stdexcept>  // for std::invalid_argument
+#include <stdexcept>  // for std::invalid_argument, std::runtime_error
 
 namespace ITS {
 namespace Propagation {
@@ -39,6 +39,7 @@ namespace LFMF {
  * 
  * @throws std::invalid_argument  If the values provided for `i`, `kind`, or
  *                                `scaling` are not valid for this function.
+ * @throws std::runtime_error     If the root finding algorithm fails to converge.
  * 
  * **References**
  *     - "Airy Functions of the third kind" are found in equation 38 of [NTIA
@@ -242,8 +243,10 @@ std::complex<double> WiRoot(
     // Check to see if there if the loop converged on an answer
     // The cnt that fails is an arbitrary number; most converge in ~5 tries
     if (cnt == 26) {
-        // No Convergence return 0 + j*0 as the root as TW() did
-        tw = std::complex<double>(0.0, 0.0);
+        std::ostringstream oss;
+        oss << "WiRoot(): Root finding algorithm did not converge after 25 "
+               "iterations using Newton's method. Exiting.";
+        throw std::runtime_error(oss.str());
     } else {
         // Converged!
         tw = ti;

--- a/src/WiRoot.cpp
+++ b/src/WiRoot.cpp
@@ -6,7 +6,6 @@
 
 #include <cmath>      // for abs, cos, pow, sin
 #include <complex>    // for std::complex
-#include <ostream>    // for std::endl
 #include <sstream>    // for std::ostringstream
 #include <stdexcept>  // for std::invalid_argument
 
@@ -109,7 +108,7 @@ std::complex<double> WiRoot(
     if (i <= 0) {
         // Input `i` must be > 0; throw an exception
         std::ostringstream oss;
-        oss << "WiRoot(): The root `i` must be > 0, not " << i << std::endl;
+        oss << "WiRoot(): The root `i` must be > 0, not " << i;
         throw std::invalid_argument(oss.str());
     };
 
@@ -119,7 +118,7 @@ std::complex<double> WiRoot(
         oss << "WiRoot(): `scaling` must be one of `HUFFORD` ("
             << static_cast<int>(AiryScaling::HUFFORD) << ") or `WAIT` ("
             << static_cast<int>(AiryScaling::WAIT) << "), not "
-            << static_cast<int>(scaling) << std::endl;
+            << static_cast<int>(scaling);
         throw std::invalid_argument(oss.str());
     };
 
@@ -129,7 +128,7 @@ std::complex<double> WiRoot(
         oss << "WiRoot(): `kind` must be one of `WTWO` ("
             << static_cast<int>(AiryKind::WTWO) << ") or `WONE` ("
             << static_cast<int>(AiryKind::WONE) << "), not "
-            << static_cast<int>(kind) << std::endl;
+            << static_cast<int>(kind);
         throw std::invalid_argument(oss.str());
     };
     // Input parameters verified

--- a/src/WiRoot.cpp
+++ b/src/WiRoot.cpp
@@ -61,7 +61,7 @@ std::complex<double> WiRoot(
     double t, tt;            // Temp
     double eps;              // Temp
     int cnt;                 // Temp
-    AiryKind dkind;  // Temp
+    AiryKind dkind;          // Temp
 
     // From the NIST DLMF (Digital Library of Mathematical Functions)
     // http://dlmf.nist.gov/
@@ -106,13 +106,13 @@ std::complex<double> WiRoot(
         return tw;
     };
 
-    if ((scaling != HUFFORD) && (scaling != WAIT)) {
+    if ((scaling != AiryScaling::HUFFORD) && (scaling != AiryScaling::WAIT)) {
         // There is an input parameter error; printf("WiRoot(): The scaling must be HUFFORD (%d) or WAIT (%d)\n", HUFFORD, WAIT);
         tw = std::complex<double>(-997.7, -997.7);
         return tw;
     };
 
-    if ((kind != WTWO) && (kind != WONE)) {
+    if ((kind != AiryKind::WTWO) && (kind != AiryKind::WONE)) {
         // There is an input parameter error; printf("WiRoot(): The kind must be W1 (%d) or W2 (%d)\n", WONE, WTWO);
         tw = std::complex<double>(-996.6, -996.6);
         return tw;
@@ -133,31 +133,31 @@ std::complex<double> WiRoot(
     // This is the similar to the initial scaling that is done in Airy()
     // Note that W1 Wait = Wi(2) Hufford and W2 Wait = Wi(1) Hufford
     // So the following inequalities keep this all straight
-    if ((kind == WONE && scaling == HUFFORD)
-        || (kind == WTWO && scaling == WAIT)) {
+    if ((kind == AiryKind::WONE && scaling == AiryScaling::HUFFORD)
+        || (kind == AiryKind::WTWO && scaling == AiryScaling::WAIT)) {
         // Wi(1)(Z) in Eqn 38 Hufford NTIA Report 87-219 or Wait W2
         ph = std::complex<double>(
             std::cos(-2.0 * PI / 3.0), std::sin(-2.0 * PI / 3.0)
         );
         // Set the dkind flag
-        if (scaling == WAIT) {
-            dkind = DWTWO;
+        if (scaling == AiryScaling::WAIT) {
+            dkind = AiryKind::DWTWO;
         } else {
-            dkind = DWONE;
+            dkind = AiryKind::DWONE;
         };
-    } else if ((kind == WTWO && scaling == HUFFORD)
-               || (kind == WONE && scaling == WAIT)) {
+    } else if ((kind == AiryKind::WTWO && scaling == AiryScaling::HUFFORD)
+               || (kind == AiryKind::WONE && scaling == AiryScaling::WAIT)) {
         // Wi(2)(Z) in Eqn 38 Hufford NTIA Report 87-219 or Wait W1
         ph = std::complex<double>(
             std::cos(2.0 * PI / 3.0), std::sin(2.0 * PI / 3.0)
         );
-        if (scaling == WAIT) {
-            dkind = DWONE;
+        if (scaling == AiryScaling::WAIT) {
+            dkind = AiryKind::DWONE;
         } else {
-            dkind = DWTWO;
+            dkind = AiryKind::DWTWO;
         };
     } else {
-        dkind = DWONE;  // Not used, initialization for compile warning
+        dkind = AiryKind::DWONE;  // Not used, initialized for compile warning
     }
 
     // Note: The zeros of the Airy functions i[ak'] and Ak'[ak], ak' and ak, are on the negative real axis.

--- a/src/WiRoot.cpp
+++ b/src/WiRoot.cpp
@@ -41,8 +41,8 @@ namespace LFMF {
  *       "A General Theory of Radio Propagation through a Stratified Atmosphere",
  *       George Hufford, July 1987.
  * 
- * @see ITS::Propagation::LFMF::AiryFunctionKind
- * @see ITS::Propagation::LFMF::AiryFunctionScaling
+ * @see ITS::Propagation::LFMF::AiryKind
+ * @see ITS::Propagation::LFMF::AiryScaling
  * @see ITS::Propagation::LFMF::Airy
  ******************************************************************************/
 std::complex<double> WiRoot(
@@ -50,8 +50,8 @@ std::complex<double> WiRoot(
     std::complex<double> &DWi,
     const std::complex<double> q,
     std::complex<double> &Wi,
-    const AiryFunctionKind kind,
-    const AiryFunctionScaling scaling
+    const AiryKind kind,
+    const AiryScaling scaling
 ) {
     std::complex<double> ph;  // Airy root phase
     std::complex<double> ti;  // ith cplx root of Wi'(2)(ti) - q*Wi(2)(ti) = 0
@@ -61,7 +61,7 @@ std::complex<double> WiRoot(
     double t, tt;            // Temp
     double eps;              // Temp
     int cnt;                 // Temp
-    AiryFunctionKind dkind;  // Temp
+    AiryKind dkind;  // Temp
 
     // From the NIST DLMF (Digital Library of Mathematical Functions)
     // http://dlmf.nist.gov/

--- a/src/WiRoot.cpp
+++ b/src/WiRoot.cpp
@@ -4,8 +4,11 @@
 
 #include "LFMF.h"
 
-#include <cmath>    // for abs, cos, pow, sin
-#include <complex>  // for std::complex
+#include <cmath>      // for abs, cos, pow, sin
+#include <complex>    // for std::complex
+#include <ostream>    // for std::endl
+#include <sstream>    // for std::ostringstream
+#include <stdexcept>  // for std::invalid_argument
 
 namespace ITS {
 namespace Propagation {
@@ -25,15 +28,18 @@ namespace LFMF {
  * kind and scale are used here as they are in `Airy()` for consistency.
  *
  * @param[in]  i        The @f$ i @f$-th complex root of
- *                      @f$ Wi'^{(2)}(ti) - q*Wi^{(2)}(ti) @f$, starting with 1
+ *                      @f$ Wi'^{(2)}(ti) - q*Wi^{(2)}(ti) @f$, starting with 1.
  * @param[in]  q        Intermediate value: @f$ -j \nu \delta @f$
- * @param[in]  kind     Kind of Airy function to use
- * @param[in]  scaling  Type of scaling to use
+ * @param[in]  kind     Kind of Airy function to use, either `WONE` or `WTWO`
+ * @param[in]  scaling  Type of scaling to use, either `HUFFORD` or `WAIT`
  * @param[out] DWi      Derivative of "Airy function of the third kind"
  *                      @f$ Wi'^{(2)}(ti) @f$
  * @param[out] Wi       "Airy function of the third kind" @f$ Wi^{(2)}(ti) @f$
  * @return              The @f$ i @f$-th complex root of the "Airy function of
  *                      the third kind"
+ * 
+ * @throws std::invalid_argument If the values provided for `i`, `kind`, or `scaling`
+ *                               are not valid for this function.
  * 
  * **References**
  *     - "Airy Functions of the third kind" are found in equation 38 of [NTIA
@@ -101,21 +107,30 @@ std::complex<double> WiRoot(
     // Verify that the input data is correct
     // Make sure that the desired root is greater than or equal to one
     if (i <= 0) {
-        // There is an input parameter error; printf("WiRoot(): The root must be >= 0 (%d)\n", i);
-        tw = std::complex<double>(-998.8, -998.8);
-        return tw;
+        // Input `i` must be > 0; throw an exception
+        std::ostringstream oss;
+        oss << "WiRoot(): The root `i` must be > 0, not " << i << std::endl;
+        throw std::invalid_argument(oss.str());
     };
 
     if ((scaling != AiryScaling::HUFFORD) && (scaling != AiryScaling::WAIT)) {
-        // There is an input parameter error; printf("WiRoot(): The scaling must be HUFFORD (%d) or WAIT (%d)\n", HUFFORD, WAIT);
-        tw = std::complex<double>(-997.7, -997.7);
-        return tw;
+        // Input `scaling` is invalid; throw an exception
+        std::ostringstream oss;
+        oss << "WiRoot(): `scaling` must be one of `HUFFORD` ("
+            << static_cast<int>(AiryScaling::HUFFORD) << ") or `WAIT` ("
+            << static_cast<int>(AiryScaling::WAIT) << "), not "
+            << static_cast<int>(scaling) << std::endl;
+        throw std::invalid_argument(oss.str());
     };
 
     if ((kind != AiryKind::WTWO) && (kind != AiryKind::WONE)) {
-        // There is an input parameter error; printf("WiRoot(): The kind must be W1 (%d) or W2 (%d)\n", WONE, WTWO);
-        tw = std::complex<double>(-996.6, -996.6);
-        return tw;
+        // Input `kind` is invalid; throw an exception
+        std::ostringstream oss;
+        oss << "WiRoot(): `kind` must be one of `WTWO` ("
+            << static_cast<int>(AiryKind::WTWO) << ") or `WONE` ("
+            << static_cast<int>(AiryKind::WONE) << "), not "
+            << static_cast<int>(kind) << std::endl;
+        throw std::invalid_argument(oss.str());
     };
     // Input parameters verified
 

--- a/src/WiRoot.cpp
+++ b/src/WiRoot.cpp
@@ -38,8 +38,8 @@ namespace LFMF {
  * @return              The @f$ i @f$-th complex root of the "Airy function of
  *                      the third kind"
  * 
- * @throws std::invalid_argument If the values provided for `i`, `kind`, or `scaling`
- *                               are not valid for this function.
+ * @throws std::invalid_argument  If the values provided for `i`, `kind`, or
+ *                                `scaling` are not valid for this function.
  * 
  * **References**
  *     - "Airy Functions of the third kind" are found in equation 38 of [NTIA

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,7 +7,8 @@ proplib_message("Configuring library tests ${TEST_NAME}")
 ## Include all source AND header files for tests here.
 ## Do not include the source and header files of the library under test.
 add_executable(
-    ${TEST_NAME}    
+    ${TEST_NAME}
+    "TestAiry.cpp"
     "TestLFMFReturnCode.cpp"
     "TestWiRoot.cpp"
     "TestUtils.cpp"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ proplib_message("Configuring library tests ${TEST_NAME}")
 add_executable(
     ${TEST_NAME}    
     "TestLFMFReturnCode.cpp"
+    "TestWiRoot.cpp"
     "TestUtils.cpp"
     "TestUtils.h"
 )

--- a/tests/TestAiry.cpp
+++ b/tests/TestAiry.cpp
@@ -1,0 +1,232 @@
+/** @file TestAiry.cpp
+ * Unit tests for the Airy function.
+ */
+
+#include "TestUtils.h"
+
+#include <cmath>      // for cos, sin, sqrt
+#include <stdexcept>  // for std::invalid_argument
+
+constexpr double AIRY_TOL = 1.0e-4;
+
+/** Test fixture provides valid inputs for Airy */
+class TestAiry: public ::testing::Test {
+    protected:
+        void SetUp() override {
+            // Initialize valid inputs
+            Z = {8.0, 8.0};  // Evaluated with asymptotic solution
+            kind = AiryKind::AIRY;
+            scaling = AiryScaling::NONE;
+        }
+        // input variables
+        std::complex<double> Z;
+        AiryKind kind;
+        AiryScaling scaling;
+        // variables to use for comparisons
+        std::complex<double> expected;
+        std::complex<double> scale_factor;  // to translate HUFFORD/WAIT
+        // output variable
+        std::complex<double> airy;
+};
+
+/** Exercise the function for AiryKind::AIRY with all scaling options */
+TEST_F(TestAiry, AsymptoticAIRY) {
+    // Scaling does not apply to AiryKind::AIRY
+    expected = {6.57693e-07, 9.31233e-06};
+
+    airy = Airy(Z, kind, scaling);
+    EXPECT_NEAR(airy.real(), expected.real(), AIRY_TOL);
+    EXPECT_NEAR(airy.imag(), expected.imag(), AIRY_TOL);
+
+    scaling = AiryScaling::HUFFORD;
+    airy = Airy(Z, kind, scaling);
+    EXPECT_NEAR(airy.real(), expected.real(), AIRY_TOL);
+    EXPECT_NEAR(airy.imag(), expected.imag(), AIRY_TOL);
+
+    scaling = AiryScaling::WAIT;
+    airy = Airy(Z, kind, scaling);
+    EXPECT_NEAR(airy.real(), expected.real(), AIRY_TOL);
+    EXPECT_NEAR(airy.imag(), expected.imag(), AIRY_TOL);
+}
+
+/** Exercise the function for AiryKind::AIRYD with all scaling options */
+TEST_F(TestAiry, AsymptoticAIRYD) {
+    // Scaling does not apply to AiryKind::AIRYD
+    expected = {9.79016e-06, -2.99217e-05};
+    kind = AiryKind::AIRYD;
+
+    airy = Airy(Z, kind, scaling);
+    EXPECT_NEAR(airy.real(), expected.real(), AIRY_TOL);
+    EXPECT_NEAR(airy.imag(), expected.imag(), AIRY_TOL);
+
+    scaling = AiryScaling::HUFFORD;
+    airy = Airy(Z, kind, scaling);
+    EXPECT_NEAR(airy.real(), expected.real(), AIRY_TOL);
+    EXPECT_NEAR(airy.imag(), expected.imag(), AIRY_TOL);
+
+    scaling = AiryScaling::WAIT;
+    airy = Airy(Z, kind, scaling);
+    EXPECT_NEAR(airy.real(), expected.real(), AIRY_TOL);
+    EXPECT_NEAR(airy.imag(), expected.imag(), AIRY_TOL);
+}
+
+/** Exercise the function for AiryKind::BAIRY with all scaling options */
+TEST_F(TestAiry, AsymptoticBAIRY) {
+    expected = {-1605.15434, -4807.19999};
+    kind = AiryKind::BAIRY;
+    // Scaling does not apply to AiryKind::BAIRY
+
+    airy = Airy(Z, kind, scaling);
+    EXPECT_NEAR(airy.real(), expected.real(), AIRY_TOL);
+    EXPECT_NEAR(airy.imag(), expected.imag(), AIRY_TOL);
+
+    scaling = AiryScaling::HUFFORD;
+    airy = Airy(Z, kind, scaling);
+    EXPECT_NEAR(airy.real(), expected.real(), AIRY_TOL);
+    EXPECT_NEAR(airy.imag(), expected.imag(), AIRY_TOL);
+
+    scaling = AiryScaling::WAIT;
+    airy = Airy(Z, kind, scaling);
+    EXPECT_NEAR(airy.real(), expected.real(), AIRY_TOL);
+    EXPECT_NEAR(airy.imag(), expected.imag(), AIRY_TOL);
+}
+
+/** Exercise the function for AiryKind::BAIRYD with all scaling options */
+TEST_F(TestAiry, AsymptoticBAIRYD) {
+    expected = {1301.23297, -16955.98329};
+    kind = AiryKind::BAIRYD;
+    // Scaling does not apply to AiryKind::BAIRYD
+
+    airy = Airy(Z, kind, scaling);
+    EXPECT_NEAR(airy.real(), expected.real(), AIRY_TOL);
+    EXPECT_NEAR(airy.imag(), expected.imag(), AIRY_TOL);
+
+    scaling = AiryScaling::HUFFORD;
+    airy = Airy(Z, kind, scaling);
+    EXPECT_NEAR(airy.real(), expected.real(), AIRY_TOL);
+    EXPECT_NEAR(airy.imag(), expected.imag(), AIRY_TOL);
+
+    scaling = AiryScaling::WAIT;
+    airy = Airy(Z, kind, scaling);
+    EXPECT_NEAR(airy.real(), expected.real(), AIRY_TOL);
+    EXPECT_NEAR(airy.imag(), expected.imag(), AIRY_TOL);
+}
+
+/** Exercise the function for AiryKind::WONE with all scaling options */
+TEST_F(TestAiry, AsymptoticWONE) {
+    // Expected values with HUFFORD scaling
+    expected = {-4807.19999, 1605.15435};
+    scale_factor = {0.0, std::sqrt(PI)};  // translates to WAIT
+    kind = AiryKind::WONE;
+
+    // WONE with scaling NONE is invalid
+
+    scaling = AiryScaling::HUFFORD;
+    airy = Airy(Z, kind, scaling);
+    EXPECT_NEAR(airy.real(), expected.real(), AIRY_TOL);
+    EXPECT_NEAR(airy.imag(), expected.imag(), AIRY_TOL);
+
+    scaling = AiryScaling::WAIT;
+    airy = Airy(Z, kind, scaling);
+    EXPECT_NEAR(airy.real(), (expected * scale_factor).real(), 1.0e-3);
+    EXPECT_NEAR(airy.imag(), (expected * scale_factor).imag(), 1.0e-3);
+}
+
+/** Exercise the function for AiryKind::DWONE with all scaling options */
+TEST_F(TestAiry, AsymptoticDWONE) {
+    // Expected values with HUFFORD scaling
+    expected = {-16955.983274, -1301.233026};
+    scale_factor = {0.0, std::sqrt(PI)};  // translates to WAIT
+    kind = AiryKind::DWONE;
+
+    // DWONE with scaling NONE is invalid
+
+    scaling = AiryScaling::HUFFORD;
+    airy = Airy(Z, kind, scaling);
+    EXPECT_NEAR(airy.real(), expected.real(), AIRY_TOL);
+    EXPECT_NEAR(airy.imag(), expected.imag(), AIRY_TOL);
+
+    scaling = AiryScaling::WAIT;
+    airy = Airy(Z, kind, scaling);
+    EXPECT_NEAR(airy.real(), (expected * scale_factor).real(), 1.0e-3);
+    EXPECT_NEAR(airy.imag(), (expected * scale_factor).imag(), 1.0e-3);
+}
+
+/** Exercise the function for AiryKind::WTWO with all scaling options */
+TEST_F(TestAiry, AsymptoticWTWO) {
+    // Expected values with HUFFORD scaling
+    expected = {4807.19999, -1605.15435};  // translates to WAIT
+    // Scaling factor to translate expected result
+    scale_factor = {0.0, -std::sqrt(PI)};
+    kind = AiryKind::WTWO;
+
+    // WTWO with scaling NONE is invalid
+
+    scaling = AiryScaling::HUFFORD;
+    airy = Airy(Z, kind, scaling);
+    EXPECT_NEAR(airy.real(), expected.real(), AIRY_TOL);
+    EXPECT_NEAR(airy.imag(), expected.imag(), AIRY_TOL);
+
+    scaling = AiryScaling::WAIT;
+    airy = Airy(Z, kind, scaling);
+    EXPECT_NEAR(airy.real(), (expected * scale_factor).real(), 1.0e-3);
+    EXPECT_NEAR(airy.imag(), (expected * scale_factor).imag(), 1.0e-3);
+}
+
+/** Exercise the function for AiryKind::DWTWO with all scaling options */
+TEST_F(TestAiry, AsymptoticDWTWO) {
+    // Expected values with HUFFORD scaling
+    expected = {16955.983313, 1301.232906};
+    scale_factor = {0.0, -std::sqrt(PI)};  // translates to WAIT
+    kind = AiryKind::DWTWO;
+
+    // DWTWO with scaling NONE is invalid
+
+    scaling = AiryScaling::HUFFORD;
+    airy = Airy(Z, kind, scaling);
+    EXPECT_NEAR(airy.real(), expected.real(), AIRY_TOL);
+    EXPECT_NEAR(airy.imag(), expected.imag(), AIRY_TOL);
+
+    scaling = AiryScaling::WAIT;
+    airy = Airy(Z, kind, scaling);
+    EXPECT_NEAR(airy.real(), (expected * scale_factor).real(), 1.0e-3);
+    EXPECT_NEAR(airy.imag(), (expected * scale_factor).imag(), 1.0e-3);
+}
+
+/** Ensure Hufford's Airy functions of the third kind meet their definitions */
+TEST_F(TestAiry, TestThirdKindDefinition) {
+    std::complex<double> j(0, 1.0);
+    std::complex<double> wi, ai, bi;
+    scaling = AiryScaling::HUFFORD;
+
+    // Test that Wi(1)(z) = Ai(z) - j*Bi(z)
+    wi = Airy(Z, AiryKind::WONE, scaling);
+    ai = Airy(Z, AiryKind::AIRY, AiryScaling::NONE);
+    bi = Airy(Z, AiryKind::BAIRY, AiryScaling::NONE);
+    expected = ai - j * bi;  // -4807.2, 1605.15
+    EXPECT_NEAR(wi.real(), expected.real(), 1.0e-5);
+    EXPECT_NEAR(wi.imag(), expected.imag(), 1.0e-5);
+
+    // Test that Wi(2)(z) = Ai(z) + j*Bi(z)
+    wi = Airy(Z, AiryKind::WTWO, scaling);
+    expected = ai + j * bi;  // 4807.2, -1605.15
+    EXPECT_NEAR(wi.real(), expected.real(), 1.0e-5);
+    EXPECT_NEAR(wi.imag(), expected.imag(), 1.0e-5);
+}
+
+/** Invalid `scaling` input throws an exception */
+TEST_F(TestAiry, InvalidScaling) {
+    scaling = static_cast<AiryScaling>(-1);
+    EXPECT_THROW(Airy(Z, kind, scaling), std::invalid_argument);
+
+    // Scaling NONE is invalid with Airy functions of the third kind
+    scaling = AiryScaling::NONE;
+    kind = AiryKind::WONE;
+    EXPECT_THROW(Airy(Z, kind, scaling), std::invalid_argument);
+    kind = AiryKind::WTWO;
+    EXPECT_THROW(Airy(Z, kind, scaling), std::invalid_argument);
+    kind = AiryKind::DWONE;
+    EXPECT_THROW(Airy(Z, kind, scaling), std::invalid_argument);
+    kind = AiryKind::DWTWO;
+    EXPECT_THROW(Airy(Z, kind, scaling), std::invalid_argument);
+}

--- a/tests/TestLFMFReturnCode.cpp
+++ b/tests/TestLFMFReturnCode.cpp
@@ -20,6 +20,10 @@ class TestLFMFReturnCode: public ::testing::Test {
         std::vector<LFMFTestData> testData;
 
         std::string fileName = "LFMF_Examples.csv";
+
+        // Initialize common output variables
+        ReturnCode rtn;
+        Result result;
 };
 
 /** Test case to verify LFMF results are correct */
@@ -31,9 +35,7 @@ TEST_F(TestLFMFReturnCode, ReturnSuccess) {
 
     for (const auto &data : testData) {
         if (data.rtn == SUCCESS) {
-            Result result;
-
-            int rtn = LFMF_CPP(
+            rtn = LFMF_CPP(
                 data.h_tx__meter,
                 data.h_rx__meter,
                 data.f__mhz,
@@ -45,7 +47,6 @@ TEST_F(TestLFMFReturnCode, ReturnSuccess) {
                 data.pol,
                 result
             );
-
             EXPECT_EQ(rtn, data.rtn);
             EXPECT_NEAR(result.A_btl__db, data.A_btl__db, ABSTOL__DB);
             EXPECT_NEAR(result.E_dBuVm, data.E_dBuVm, ABSTOL__DB);
@@ -59,9 +60,7 @@ TEST_F(TestLFMFReturnCode, ReturnSuccess) {
 TEST_F(TestLFMFReturnCode, InvalidTXTerminalHeight) {
     for (const auto &data : testData) {
         if (data.rtn == ERROR__TX_TERMINAL_HEIGHT) {
-            Result result;
-
-            int rtn = LFMF_CPP(
+            rtn = LFMF_CPP(
                 data.h_tx__meter,
                 data.h_rx__meter,
                 data.f__mhz,
@@ -73,7 +72,6 @@ TEST_F(TestLFMFReturnCode, InvalidTXTerminalHeight) {
                 data.pol,
                 result
             );
-
             EXPECT_EQ(rtn, ERROR__TX_TERMINAL_HEIGHT);
         }
     }
@@ -83,9 +81,7 @@ TEST_F(TestLFMFReturnCode, InvalidTXTerminalHeight) {
 TEST_F(TestLFMFReturnCode, InvalidRXTerminalHeight) {
     for (const auto &data : testData) {
         if (data.rtn == ERROR__RX_TERMINAL_HEIGHT) {
-            Result result;
-
-            int rtn = LFMF_CPP(
+            rtn = LFMF_CPP(
                 data.h_tx__meter,
                 data.h_rx__meter,
                 data.f__mhz,
@@ -97,7 +93,6 @@ TEST_F(TestLFMFReturnCode, InvalidRXTerminalHeight) {
                 data.pol,
                 result
             );
-
             EXPECT_EQ(rtn, ERROR__RX_TERMINAL_HEIGHT);
         }
     }
@@ -107,9 +102,7 @@ TEST_F(TestLFMFReturnCode, InvalidRXTerminalHeight) {
 TEST_F(TestLFMFReturnCode, InvalidFrequency) {
     for (const auto &data : testData) {
         if (data.rtn == ERROR__FREQUENCY) {
-            Result result;
-
-            int rtn = LFMF_CPP(
+            rtn = LFMF_CPP(
                 data.h_tx__meter,
                 data.h_rx__meter,
                 data.f__mhz,
@@ -121,7 +114,6 @@ TEST_F(TestLFMFReturnCode, InvalidFrequency) {
                 data.pol,
                 result
             );
-
             EXPECT_EQ(rtn, ERROR__FREQUENCY);
         }
     }
@@ -131,9 +123,7 @@ TEST_F(TestLFMFReturnCode, InvalidFrequency) {
 TEST_F(TestLFMFReturnCode, InvalidTransmitPower) {
     for (const auto &data : testData) {
         if (data.rtn == ERROR__TX_POWER) {
-            Result result;
-
-            int rtn = LFMF_CPP(
+            rtn = LFMF_CPP(
                 data.h_tx__meter,
                 data.h_rx__meter,
                 data.f__mhz,
@@ -145,7 +135,6 @@ TEST_F(TestLFMFReturnCode, InvalidTransmitPower) {
                 data.pol,
                 result
             );
-
             EXPECT_EQ(rtn, ERROR__TX_POWER);
         }
     }
@@ -155,9 +144,7 @@ TEST_F(TestLFMFReturnCode, InvalidTransmitPower) {
 TEST_F(TestLFMFReturnCode, InvalidSurfaceRefractivity) {
     for (const auto &data : testData) {
         if (data.rtn == ERROR__SURFACE_REFRACTIVITY) {
-            Result result;
-
-            int rtn = LFMF_CPP(
+            rtn = LFMF_CPP(
                 data.h_tx__meter,
                 data.h_rx__meter,
                 data.f__mhz,
@@ -169,7 +156,6 @@ TEST_F(TestLFMFReturnCode, InvalidSurfaceRefractivity) {
                 data.pol,
                 result
             );
-
             EXPECT_EQ(rtn, ERROR__SURFACE_REFRACTIVITY);
         }
     }
@@ -179,9 +165,7 @@ TEST_F(TestLFMFReturnCode, InvalidSurfaceRefractivity) {
 TEST_F(TestLFMFReturnCode, InvalidPathDistance) {
     for (const auto &data : testData) {
         if (data.rtn == ERROR__PATH_DISTANCE) {
-            Result result;
-
-            int rtn = LFMF_CPP(
+            rtn = LFMF_CPP(
                 data.h_tx__meter,
                 data.h_rx__meter,
                 data.f__mhz,
@@ -193,7 +177,6 @@ TEST_F(TestLFMFReturnCode, InvalidPathDistance) {
                 data.pol,
                 result
             );
-
             EXPECT_EQ(rtn, ERROR__PATH_DISTANCE);
         }
     }
@@ -203,9 +186,7 @@ TEST_F(TestLFMFReturnCode, InvalidPathDistance) {
 TEST_F(TestLFMFReturnCode, InvalidEpsilon) {
     for (const auto &data : testData) {
         if (data.rtn == ERROR__EPSILON) {
-            Result result;
-
-            int rtn = LFMF_CPP(
+            rtn = LFMF_CPP(
                 data.h_tx__meter,
                 data.h_rx__meter,
                 data.f__mhz,
@@ -217,7 +198,6 @@ TEST_F(TestLFMFReturnCode, InvalidEpsilon) {
                 data.pol,
                 result
             );
-
             EXPECT_EQ(rtn, ERROR__EPSILON);
         }
     }
@@ -227,9 +207,7 @@ TEST_F(TestLFMFReturnCode, InvalidEpsilon) {
 TEST_F(TestLFMFReturnCode, InvalidSigma) {
     for (const auto &data : testData) {
         if (data.rtn == ERROR__SIGMA) {
-            Result result;
-
-            int rtn = LFMF_CPP(
+            rtn = LFMF_CPP(
                 data.h_tx__meter,
                 data.h_rx__meter,
                 data.f__mhz,
@@ -241,7 +219,6 @@ TEST_F(TestLFMFReturnCode, InvalidSigma) {
                 data.pol,
                 result
             );
-
             EXPECT_EQ(rtn, ERROR__SIGMA);
         }
     }
@@ -249,42 +226,12 @@ TEST_F(TestLFMFReturnCode, InvalidSigma) {
 
 /** Test case to verify LFMF input polarization is invalid */
 TEST_F(TestLFMFReturnCode, InvalidPolarization) {
+    bool polarization_checked = false;
     for (const auto &data : testData) {
-        Result result;
-
-        int rtn = LFMF(
-            data.h_tx__meter,
-            data.h_rx__meter,
-            data.f__mhz,
-            data.P_tx__watt,
-            data.N_s,
-            data.d__km,
-            data.epsilon,
-            data.sigma,
-            -1,
-            result
-        );
-
-        EXPECT_EQ(rtn, ERROR__POLARIZATION);
-
-        rtn = LFMF(
-            data.h_tx__meter,
-            data.h_rx__meter,
-            data.f__mhz,
-            data.P_tx__watt,
-            data.N_s,
-            data.d__km,
-            data.epsilon,
-            data.sigma,
-            3,
-            result
-        );
-
-        EXPECT_EQ(rtn, ERROR__POLARIZATION);
+        // Run any tests cases which should cause polarization error
         if (data.rtn == ERROR__POLARIZATION) {
-            Result result;
-
-            int rtn = LFMF_CPP(
+            polarization_checked = true;
+            rtn = LFMF_CPP(
                 data.h_tx__meter,
                 data.h_rx__meter,
                 data.f__mhz,
@@ -296,8 +243,9 @@ TEST_F(TestLFMFReturnCode, InvalidPolarization) {
                 data.pol,
                 result
             );
-
             EXPECT_EQ(rtn, ERROR__POLARIZATION);
         }
     }
+    // Ensure this test was exercised by at least one test case
+    EXPECT_EQ(polarization_checked, true);
 }

--- a/tests/TestLFMFReturnCode.cpp
+++ b/tests/TestLFMFReturnCode.cpp
@@ -33,7 +33,7 @@ TEST_F(TestLFMFReturnCode, ReturnSuccess) {
         if (data.rtn == SUCCESS) {
             Result result;
 
-            int rtn = LFMF(
+            int rtn = LFMF_CPP(
                 data.h_tx__meter,
                 data.h_rx__meter,
                 data.f__mhz,
@@ -61,7 +61,7 @@ TEST_F(TestLFMFReturnCode, InvalidTXTerminalHeight) {
         if (data.rtn == ERROR__TX_TERMINAL_HEIGHT) {
             Result result;
 
-            int rtn = LFMF(
+            int rtn = LFMF_CPP(
                 data.h_tx__meter,
                 data.h_rx__meter,
                 data.f__mhz,
@@ -85,7 +85,7 @@ TEST_F(TestLFMFReturnCode, InvalidRXTerminalHeight) {
         if (data.rtn == ERROR__RX_TERMINAL_HEIGHT) {
             Result result;
 
-            int rtn = LFMF(
+            int rtn = LFMF_CPP(
                 data.h_tx__meter,
                 data.h_rx__meter,
                 data.f__mhz,
@@ -109,7 +109,7 @@ TEST_F(TestLFMFReturnCode, InvalidFrequency) {
         if (data.rtn == ERROR__FREQUENCY) {
             Result result;
 
-            int rtn = LFMF(
+            int rtn = LFMF_CPP(
                 data.h_tx__meter,
                 data.h_rx__meter,
                 data.f__mhz,
@@ -133,7 +133,7 @@ TEST_F(TestLFMFReturnCode, InvalidTransmitPower) {
         if (data.rtn == ERROR__TX_POWER) {
             Result result;
 
-            int rtn = LFMF(
+            int rtn = LFMF_CPP(
                 data.h_tx__meter,
                 data.h_rx__meter,
                 data.f__mhz,
@@ -157,7 +157,7 @@ TEST_F(TestLFMFReturnCode, InvalidSurfaceRefractivity) {
         if (data.rtn == ERROR__SURFACE_REFRACTIVITY) {
             Result result;
 
-            int rtn = LFMF(
+            int rtn = LFMF_CPP(
                 data.h_tx__meter,
                 data.h_rx__meter,
                 data.f__mhz,
@@ -181,7 +181,7 @@ TEST_F(TestLFMFReturnCode, InvalidPathDistance) {
         if (data.rtn == ERROR__PATH_DISTANCE) {
             Result result;
 
-            int rtn = LFMF(
+            int rtn = LFMF_CPP(
                 data.h_tx__meter,
                 data.h_rx__meter,
                 data.f__mhz,
@@ -205,7 +205,7 @@ TEST_F(TestLFMFReturnCode, InvalidEpsilon) {
         if (data.rtn == ERROR__EPSILON) {
             Result result;
 
-            int rtn = LFMF(
+            int rtn = LFMF_CPP(
                 data.h_tx__meter,
                 data.h_rx__meter,
                 data.f__mhz,
@@ -229,7 +229,7 @@ TEST_F(TestLFMFReturnCode, InvalidSigma) {
         if (data.rtn == ERROR__SIGMA) {
             Result result;
 
-            int rtn = LFMF(
+            int rtn = LFMF_CPP(
                 data.h_tx__meter,
                 data.h_rx__meter,
                 data.f__mhz,
@@ -284,7 +284,7 @@ TEST_F(TestLFMFReturnCode, InvalidPolarization) {
         if (data.rtn == ERROR__POLARIZATION) {
             Result result;
 
-            int rtn = LFMF(
+            int rtn = LFMF_CPP(
                 data.h_tx__meter,
                 data.h_rx__meter,
                 data.f__mhz,

--- a/tests/TestWiRoot.cpp
+++ b/tests/TestWiRoot.cpp
@@ -1,0 +1,95 @@
+/** @file test_TestWiRoot.cpp
+ * Unit tests for WiRoot function.
+ */
+
+#include "TestUtils.h"
+
+#include <complex>
+#include <stdexcept>
+
+/** Test fixture provides valid inputs for WiRoot */
+class TestWiRoot: public ::testing::Test {
+        void SetUp() override {
+            // Initialize valid inputs
+            i = 1;
+            q = {1.0, 1.0};
+            kind = AiryKind::WONE;
+            scaling = AiryScaling::HUFFORD;
+        }
+    protected:
+        std::complex<double> DWi, Wi;
+        int i;
+        std::complex<double> q;
+        AiryKind kind;
+        AiryScaling scaling;
+        std::complex<double> root;
+};
+
+/** Valid test case: AiryKind::WONE */
+TEST_F(TestWiRoot, AiryKindWONE) {
+    // Test for scaling = HUFFORD
+    root = WiRoot(i, DWi, q, Wi, kind, scaling);
+    EXPECT_DOUBLE_EQ(root.real(), 1.4829223351194638);
+    EXPECT_DOUBLE_EQ(root.imag(), 1.2843356310540217);
+
+    // Test for scaling = WAIT
+    root = WiRoot(i, DWi, q, Wi, kind, AiryScaling::WAIT);
+    EXPECT_DOUBLE_EQ(root.real(), 0.22646319357739417);
+    EXPECT_DOUBLE_EQ(root.imag(), 1.7542471947545168);
+}
+
+/** Valid test case: AiryKind::WTWO */
+TEST_F(TestWiRoot, AiryKindWTWO) {
+    kind = AiryKind::WTWO;
+    // Test for scaling = HUFFORD
+    root = WiRoot(i, DWi, q, Wi, kind, scaling);
+    EXPECT_DOUBLE_EQ(root.real(), 0.22646319357739642);
+    EXPECT_DOUBLE_EQ(root.imag(), 1.7542471947545142);
+
+    // Test for scaling = WAIT
+    root = WiRoot(i, DWi, q, Wi, kind, AiryScaling::WAIT);
+    EXPECT_DOUBLE_EQ(root.real(), 1.482922335119464);
+    EXPECT_DOUBLE_EQ(root.imag(), 1.2843356310540215);
+}
+
+/** AiryKind::AIRY should throw an exception */
+TEST_F(TestWiRoot, AiryKindAIRY) {
+    EXPECT_THROW(
+        WiRoot(i, DWi, q, Wi, AiryKind::AIRY, scaling), std::invalid_argument
+    );
+}
+
+/** AiryKind::AIRYD should throw an exception */
+TEST_F(TestWiRoot, AiryKindAIRYD) {
+    EXPECT_THROW(
+        WiRoot(i, DWi, q, Wi, AiryKind::AIRYD, scaling), std::invalid_argument
+    );
+}
+
+/** AiryKind::BAIRY should throw an exception */
+TEST_F(TestWiRoot, AiryKindBAIRY) {
+    EXPECT_THROW(
+        WiRoot(i, DWi, q, Wi, AiryKind::BAIRY, scaling), std::invalid_argument
+    );
+}
+
+/** AiryKind::BAIRYD should throw an exception */
+TEST_F(TestWiRoot, AiryKindBAIRYD) {
+    EXPECT_THROW(
+        WiRoot(i, DWi, q, Wi, AiryKind::BAIRYD, scaling), std::invalid_argument
+    );
+}
+
+/** AiryKind::DWTWO should throw an exception */
+TEST_F(TestWiRoot, AiryKindDWTWO) {
+    EXPECT_THROW(
+        WiRoot(i, DWi, q, Wi, AiryKind::DWTWO, scaling), std::invalid_argument
+    );
+}
+
+/** AiryKind::DWONE should throw an exception */
+TEST_F(TestWiRoot, AiryKindDWONE) {
+    EXPECT_THROW(
+        WiRoot(i, DWi, q, Wi, AiryKind::DWONE, scaling), std::invalid_argument
+    );
+}

--- a/tests/TestWiRoot.cpp
+++ b/tests/TestWiRoot.cpp
@@ -9,6 +9,7 @@
 
 /** Test fixture provides valid inputs for WiRoot */
 class TestWiRoot: public ::testing::Test {
+    protected:
         void SetUp() override {
             // Initialize valid inputs
             i = 1;
@@ -16,7 +17,7 @@ class TestWiRoot: public ::testing::Test {
             kind = AiryKind::WONE;
             scaling = AiryScaling::HUFFORD;
         }
-    protected:
+        // Initialize input and output variables
         std::complex<double> DWi, Wi;
         int i;
         std::complex<double> q;

--- a/tests/TestWiRoot.cpp
+++ b/tests/TestWiRoot.cpp
@@ -52,6 +52,53 @@ TEST_F(TestWiRoot, AiryKindWTWO) {
     EXPECT_DOUBLE_EQ(root.imag(), 1.2843356310540215);
 }
 
+/** Test a set of conditions that run for small q and small i */
+TEST_F(TestWiRoot, SmallQSmallI) {
+    // In this case, the root is taken from a const array
+    q = {1.0, 1.0};
+    i = 1;
+    root = WiRoot(i, DWi, q, Wi, kind, scaling);
+    EXPECT_DOUBLE_EQ(root.real(), 1.4829223351194638);
+    EXPECT_DOUBLE_EQ(root.imag(), 1.2843356310540217);
+}
+
+/** Test a set of conditions that run for small q and large i */
+TEST_F(TestWiRoot, SmallQLargeI) {
+    // In this case, the root is approximated
+    q = {1.0, 1.0};
+    i = 11;
+    root = WiRoot(i, DWi, q, Wi, kind, scaling);
+    EXPECT_DOUBLE_EQ(root.real(), 6.7395876387056539);
+    EXPECT_DOUBLE_EQ(root.imag(), 11.460104740476151);
+}
+
+/** Test a set of conditions that run for large q and small i */
+TEST_F(TestWiRoot, LargeQSmallI) {
+    // In this case, the root is taken from a const array
+    q = {5.0, 5.0};
+    i = 1;
+    root = WiRoot(i, DWi, q, Wi, kind, scaling);
+    EXPECT_DOUBLE_EQ(root.real(), 1.2695003468987784);
+    EXPECT_DOUBLE_EQ(root.imag(), 1.9226740699637952);
+}
+/** Test a set of conditions that run for large q and large i */
+TEST_F(TestWiRoot, LargeQLargeI) {
+    // In this case, the root is approximated
+    q = {5.0, 5.0};
+    i = 11;
+    root = WiRoot(i, DWi, q, Wi, kind, scaling);
+    EXPECT_DOUBLE_EQ(root.real(), 6.9479928400612074);
+    EXPECT_DOUBLE_EQ(root.imag(), 11.742393555292688);
+}
+
+/** WiRoot should throw an exception when `i` is <= 0 */
+TEST_F(TestWiRoot, InvalidRootSelected) {
+    i = -1;
+    EXPECT_THROW(WiRoot(i, DWi, q, Wi, kind, scaling), std::invalid_argument);
+    i = 0;
+    EXPECT_THROW(WiRoot(i, DWi, q, Wi, kind, scaling), std::invalid_argument);
+}
+
 /** AiryKind::AIRY should throw an exception */
 TEST_F(TestWiRoot, AiryKindAIRY) {
     EXPECT_THROW(

--- a/tests/TestWiRoot.cpp
+++ b/tests/TestWiRoot.cpp
@@ -1,11 +1,11 @@
 /** @file TestWiRoot.cpp
- * Unit tests for WiRoot function.
+ * Unit tests for the WiRoot function.
  */
 
 #include "TestUtils.h"
 
-#include <complex>
-#include <stdexcept>
+#include <complex>    // for std::complex
+#include <stdexcept>  // for std::invalid_argument
 
 /** Test fixture provides valid inputs for WiRoot */
 class TestWiRoot: public ::testing::Test {

--- a/tests/TestWiRoot.cpp
+++ b/tests/TestWiRoot.cpp
@@ -30,13 +30,13 @@ class TestWiRoot: public ::testing::Test {
 TEST_F(TestWiRoot, AiryKindWONE) {
     // Test for scaling = HUFFORD
     root = WiRoot(i, DWi, q, Wi, kind, scaling);
-    EXPECT_DOUBLE_EQ(root.real(), 1.4829223351194638);
-    EXPECT_DOUBLE_EQ(root.imag(), 1.2843356310540217);
+    EXPECT_NEAR(root.real(), 1.4829223351194638, ABSTOL_DBL);
+    EXPECT_NEAR(root.imag(), 1.2843356310540217, ABSTOL_DBL);
 
     // Test for scaling = WAIT
     root = WiRoot(i, DWi, q, Wi, kind, AiryScaling::WAIT);
-    EXPECT_DOUBLE_EQ(root.real(), 0.22646319357739417);
-    EXPECT_DOUBLE_EQ(root.imag(), 1.7542471947545168);
+    EXPECT_NEAR(root.real(), 0.22646319357739417, ABSTOL_DBL);
+    EXPECT_NEAR(root.imag(), 1.7542471947545168, ABSTOL_DBL);
 }
 
 /** Valid test case: AiryKind::WTWO */
@@ -44,13 +44,13 @@ TEST_F(TestWiRoot, AiryKindWTWO) {
     kind = AiryKind::WTWO;
     // Test for scaling = HUFFORD
     root = WiRoot(i, DWi, q, Wi, kind, scaling);
-    EXPECT_DOUBLE_EQ(root.real(), 0.22646319357739642);
-    EXPECT_DOUBLE_EQ(root.imag(), 1.7542471947545142);
+    EXPECT_NEAR(root.real(), 0.22646319357739642, ABSTOL_DBL);
+    EXPECT_NEAR(root.imag(), 1.7542471947545142, ABSTOL_DBL);
 
     // Test for scaling = WAIT
     root = WiRoot(i, DWi, q, Wi, kind, AiryScaling::WAIT);
-    EXPECT_DOUBLE_EQ(root.real(), 1.482922335119464);
-    EXPECT_DOUBLE_EQ(root.imag(), 1.2843356310540215);
+    EXPECT_NEAR(root.real(), 1.482922335119464, ABSTOL_DBL);
+    EXPECT_NEAR(root.imag(), 1.2843356310540215, ABSTOL_DBL);
 }
 
 /** Test a set of conditions that run for small q and small i */
@@ -59,8 +59,8 @@ TEST_F(TestWiRoot, SmallQSmallI) {
     q = {1.0, 1.0};
     i = 1;
     root = WiRoot(i, DWi, q, Wi, kind, scaling);
-    EXPECT_DOUBLE_EQ(root.real(), 1.4829223351194638);
-    EXPECT_DOUBLE_EQ(root.imag(), 1.2843356310540217);
+    EXPECT_NEAR(root.real(), 1.4829223351194638, ABSTOL_DBL);
+    EXPECT_NEAR(root.imag(), 1.2843356310540217, ABSTOL_DBL);
 }
 
 /** Test a set of conditions that run for small q and large i */
@@ -69,8 +69,8 @@ TEST_F(TestWiRoot, SmallQLargeI) {
     q = {1.0, 1.0};
     i = 11;
     root = WiRoot(i, DWi, q, Wi, kind, scaling);
-    EXPECT_DOUBLE_EQ(root.real(), 6.7395876387056539);
-    EXPECT_DOUBLE_EQ(root.imag(), 11.460104740476151);
+    EXPECT_NEAR(root.real(), 6.7395876387056539, ABSTOL_DBL);
+    EXPECT_NEAR(root.imag(), 11.460104740476151, ABSTOL_DBL);
 }
 
 /** Test a set of conditions that run for large q and small i */
@@ -79,8 +79,8 @@ TEST_F(TestWiRoot, LargeQSmallI) {
     q = {5.0, 5.0};
     i = 1;
     root = WiRoot(i, DWi, q, Wi, kind, scaling);
-    EXPECT_DOUBLE_EQ(root.real(), 1.2695003468987784);
-    EXPECT_DOUBLE_EQ(root.imag(), 1.9226740699637952);
+    EXPECT_NEAR(root.real(), 1.2695003468987784, ABSTOL_DBL);
+    EXPECT_NEAR(root.imag(), 1.9226740699637952, ABSTOL_DBL);
 }
 /** Test a set of conditions that run for large q and large i */
 TEST_F(TestWiRoot, LargeQLargeI) {
@@ -88,8 +88,8 @@ TEST_F(TestWiRoot, LargeQLargeI) {
     q = {5.0, 5.0};
     i = 11;
     root = WiRoot(i, DWi, q, Wi, kind, scaling);
-    EXPECT_DOUBLE_EQ(root.real(), 6.9479928400612074);
-    EXPECT_DOUBLE_EQ(root.imag(), 11.742393555292688);
+    EXPECT_NEAR(root.real(), 6.9479928400612074, ABSTOL_DBL);
+    EXPECT_NEAR(root.imag(), 11.742393555292688, ABSTOL_DBL);
 }
 
 /** WiRoot should throw an exception when `i` is <= 0 */

--- a/tests/TestWiRoot.cpp
+++ b/tests/TestWiRoot.cpp
@@ -1,4 +1,4 @@
-/** @file test_TestWiRoot.cpp
+/** @file TestWiRoot.cpp
  * Unit tests for WiRoot function.
  */
 


### PR DESCRIPTION
- Improve internal error handling by implementing exceptions for error cases which previously returned valid (i.e. correctly typed numbers) but incorrect results.
- Minimize the LFMF wrapper around LFMF_CPP so that all validation occurs in LFMF_CPP
- Modify Airy validation to reflect that, for Airy functions of the third kind (WONE, WTWO, DWONE, DWTWO), the scaling should be HUFFORD or WAIT (not NONE).
- Modify Airy to move some variable declarations closer to where they are used
- Convert enums to enum classes to better enforce their usage
- Add unit tests for Airy and WiRoot