### PR TITLE
Fix Zenodo resource type for linked publications

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -45,12 +45,12 @@
         {
             "identifier": "https://ntia.github.io/LFMF/",
             "relation": "isDocumentedBy",
-            "resource_type": "softwaredocumentation"
+            "resource_type": "publication-softwaredocumentation"
         },
         {
             "identifier": "https://ntia.github.io/propagation-library-wiki/models/LFMF/",
             "relation": "isDocumentedBy",
-            "resource_type": "softwaredocumentation"
+            "resource_type": "publication-softwaredocumentation"
         }
     ],
     "version": "1.1"


### PR DESCRIPTION
Fixes an error which caused Zenodo DOI generation to fail. After this is merged, a v1.1-rc.2 release candidate will be tested.